### PR TITLE
mobile first default layout

### DIFF
--- a/src/features/DefaultLayout.tsx
+++ b/src/features/DefaultLayout.tsx
@@ -7,13 +7,15 @@ type DefaultLayoutProps = {
 
 const DefaultLayout = ({ children }: DefaultLayoutProps) => {
   return (
-    <div className="grid grid-cols-[256px_repeat(3,_minmax(0,_1fr))] gap-10 h-screen">
+    <div className="grid grid-cols-1 lg:grid-cols-[256px_repeat(3,_minmax(0,_1fr))] gap-10 h-screen">
       <header className="col-span-1">
         <Nav />
       </header>
-      <main className="col-span-3 pt-10 container px-20">
-        {children}
-        <footer className="absolute bottom-0 pb-4">
+      <main className="col-span-1 lg:col-span-3 pt-10 container px-20">
+        <section>
+          {children}
+        </section>
+        <footer className="p-4 text-right">
           © {new Date().getFullYear()}
           {` `}
           <a href="https://codefortulsa.org">Code For Tulsa</a>

--- a/src/features/Nav.tsx
+++ b/src/features/Nav.tsx
@@ -5,11 +5,11 @@ import Link from "next/link";
 export default function Nav() {
   return (
     <>
-      <div className="w-64 h-screen sm:relative bg-gray-900 shadow md:h-full flex-col justify-between hidden sm:flex">
+      <nav className="w-screen lg:w-64 bg-cft-black shadow flex-col justify-between">
         <div>
-          <div className="flex items-center my-6 cursor-pointer">
+          <div className="flex items-center justify-center my-6 cursor-pointer">
             <Link href={'/'}>
-              <Image src={sticker} alt="cft logo" />
+              <Image src={sticker} alt="cft logo" width={300} height={300} objectPosition="50% 50%;" />
             </Link>
           </div>
           <ul>
@@ -41,7 +41,7 @@ export default function Nav() {
             </Link>
           </ul>
         </div>
-      </div>
+      </nav>
     </>
   )
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Styling fix


* **What is the current behavior?** (You can also link to an open issue here)
Nav completely disappears on mobile and grid doesn't set to single column layout


* **What is the new behavior (if this is a feature change)?**
Mobile layout is single column to match figma. Footer set to end of content instead of overlay. 


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No, only tailwind changes


* **Other information**:
There's a separate issue for addressing the nav which should only show on `/` route. Logo link will get rerouted to '/about' which will center the landing page. For all non `/` routes we'll have a hamburger. 